### PR TITLE
fix: better support for the samples in plantuml-stdlib

### DIFF
--- a/src/directiveRegexes.ts
+++ b/src/directiveRegexes.ts
@@ -1,4 +1,4 @@
-export const INCLUDE_REGEX = /^\s*!include\s+(.*\.(plantuml|pu|puml|wsd))\s*$/i;
+export const INCLUDE_REGEX = /^\s*!include(?:url)?\s+(.*\.(plantuml|pu|puml|wsd))\s*$/i;
 export const INCLUDESUB_REGEX = /^\s*!includesub\s+(.*\.(plantuml|pu|puml|wsd))!(.*)\s*$/i;
 
 export const STARTSUB_REGEX = /^\s*!startsub\s+(.*)\s*$/i;

--- a/src/finder/codeBlockFinder.ts
+++ b/src/finder/codeBlockFinder.ts
@@ -39,7 +39,9 @@ export class CodeBlockFinder implements CodeFinder {
 
       const includedFileUrl = `${dirUrl}/${match[1]}`;
       const response = await fetch(includedFileUrl);
-      if (!response.ok) continue;
+      if (!response.ok) {
+        continue;
+      }
       let text = await response.text();
       text = await this.preprocessIncludeDirective(includedFileUrl, text);
       text = await this.preprocessIncludesubDirective(includedFileUrl, text);
@@ -64,7 +66,9 @@ export class CodeBlockFinder implements CodeFinder {
 
       const includedFileUrl = `${dirUrl}/${match[1]}`;
       const response = await fetch(includedFileUrl);
-      if (!response.ok) continue;
+      if (!response.ok) {
+        continue;
+      }
       let text = await response.text();
       text = await this.preprocessIncludeDirective(includedFileUrl, text);
       text = await this.preprocessIncludesubDirective(includedFileUrl, text);

--- a/src/finder/gitHubFinder.ts
+++ b/src/finder/gitHubFinder.ts
@@ -73,7 +73,10 @@ export class GitHubFileViewFinder implements CodeFinder {
 
       const includedFileUrl = `${dirUrl}/${match[1]}`;
       const response = await fetch(includedFileUrl);
-      if (!response.ok) continue;
+      if (!response.ok) {
+        preprocessedLines.push(line);
+        continue;
+      }
       const htmlString = await response.text();
       const $body = $(new DOMParser().parseFromString(htmlString, 'text/html')).find('body');
       const fileTexts = await this.find(includedFileUrl, $body);

--- a/src/finder/gitHubFinder.ts
+++ b/src/finder/gitHubFinder.ts
@@ -43,7 +43,10 @@ export class GitHubFileViewFinder implements CodeFinder {
 
       const includedFileUrl = `${dirUrl}/${match[1]}`;
       const response = await fetch(includedFileUrl);
-      if (!response.ok) continue;
+      if (!response.ok) {
+        preprocessedLines.push(line);
+        continue;
+      }
       const htmlString = await response.text();
       const $body = $(new DOMParser().parseFromString(htmlString, 'text/html')).find('body');
       const fileTexts = await this.find(includedFileUrl, $body);


### PR DESCRIPTION
Modified the GitHubFinder to convert samples from plantuml-stdlib:

* Recognizes the keyword `!includeurl` as a valid alias for `!include`
* Pushes lines for files that cannot be found to be processed by the plantuml server. This provides better support for permutations of filenames (e.g., !define, URLs).
* Example: [Component Diagram for Internet Banking](https://github.com/plantuml-stdlib/C4-PlantUML/blob/master/samples/C4_Component%20Diagram%20Sample%20-%20bigbankplc.puml)