### PR TITLE
fix: encoding error on recent PlantUML servers

### DIFF
--- a/src/encoder/plantUmlEncoder.ts
+++ b/src/encoder/plantUmlEncoder.ts
@@ -12,7 +12,7 @@ export const PlantUmlEncoder = {
   getImageUrl(pumlContent: string, serverUrl: string = pumlServerUrl): string {
     const textEncoder = new TextEncoder();
     const encoded = encode64(deflate(textEncoder.encode(pumlContent)));
-    return `${serverUrl}/svg/${encoded}`;
+    return `${serverUrl}/svg/~1${encoded}`;
   },
 };
 


### PR DESCRIPTION
When calling a recent version of the PlantUML server, the following error occurs:

![](https://www.plantuml.com/plantuml/svg/U9m50Ca5003etrIj4eNee6l-O0_Lh1kSL6i6e0IlsmDza0cS)

> The plugin you are using seems to generated a bad URL. This URL does not look like DEFLATE data. It looks like your plugin is using HUFFMAN encoding.

To resolve this error (until the encoding is changed) this MR adds the `~1` prefix to the URL.

For the plugin not to break for other users who use the default PlantUML server, `https://willbooster-plantuml.herokuapp.com` will need to be updated to a more recent version of PlantUML Server[^1].

[^1]: Current version used is: ```{"PlantUML":"1.2021.7","plantuml-service":"1.3.5"}```